### PR TITLE
Add language selector near playback controls

### DIFF
--- a/src/components/VersePage.tsx
+++ b/src/components/VersePage.tsx
@@ -1167,6 +1167,16 @@ const VersePage: React.FC = () => {
               <FontAwesomeIcon icon={faBrain} />
             </button>
           </div>
+          <LanguageSelector
+            selectedLanguage={selectedLanguage}
+            onLanguageChange={(lang) => {
+              setSelectedLanguage(lang);
+              if (!verseAnalysisState.translations[lang]) {
+                translateVerse(lang);
+              }
+            }}
+            availableLanguages={availableLanguages}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- display translation LanguageSelector alongside the audio/record controls

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6844855b974c8327927d41a42181b449